### PR TITLE
Fix: set minimum Ansible version to 2.4

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   company: "EGI"
   description: UMD distribution repository deployment
   license: Apache
-  min_ansible_version: 2.0
+  min_ansible_version: 2.4
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Usage of include_tasks requires ansible>=2.4