### PR TITLE
Expect the version of ntpdate to be >= the patched one

### DIFF
--- a/molecule/default/tests/test_security.py
+++ b/molecule/default/tests/test_security.py
@@ -31,5 +31,5 @@ def test_security_some_other_way(host):
         name = cve['name']
         if (host.package(name).is_installed):
             assert (str(host.package(name).version + '-' +
-                        host.package(name).release) ==
+                        host.package(name).release) >=
                     patched_version)


### PR DESCRIPTION
The version of ntpdate in has moved forward from the patched version, so the equality test is failing - it should in fact be `>=`. 

It may not be obvious that the comparison of the version number is done properly in this assertion, so I made this trivial test and verified that `==` and `<=` assertions fail.
